### PR TITLE
Hide CC-Quest when there are no collaborators for the ticket

### DIFF
--- a/scaffold/src/javascripts/ticket_sidebar.js
+++ b/scaffold/src/javascripts/ticket_sidebar.js
@@ -60,6 +60,7 @@ class TicketSidebar {
           if (collaboratorIDs.length < 1) {
             $menuButton.prop('disabled', true);
             $menuButtonContent.text(I18n.t('no-ccs'));
+            $('.main-app').addClass('hidden');
           }
           let ticketStatus = data.ticket.status;
           if (ticketStatus === 'closed') {


### PR DESCRIPTION
Whenever a ticket has no contributers, the app will be hidden automatically.